### PR TITLE
86c91jqtg SDS Different Language Versions endpoint

### DIFF
--- a/backend/app/api/sds.py
+++ b/backend/app/api/sds.py
@@ -66,6 +66,54 @@ async def sds_details(
 
 
 @router.post(
+    "/get-dif-language-versions/",
+    description="Returns list of SDS versions in different languages for a given SDS",
+    response_model=list[schemas.ListSDSSchema],
+)
+@limiter.limit("5/minute")
+async def get_dif_language_versions(
+    request: Request,
+    search_body: schemas.SDSDifLanguageVersionsBodySchema = Body(...),
+    sds_service: SDSService = sds_service_dependency,
+    fe: bool = Query(False, description="Optional 'fe' parameter"),
+):
+    try:
+        return await sds_service.get_dif_language_versions(search=search_body, fe=fe)
+    except (SDSAPIParamsRequired, SDSBadRequestException) as ex:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                ex.args[0]
+                if len(ex.args) > 0 and ex.args[0]
+                else "At least one param is required"
+            ),
+        )
+    except SDSAPIRequestNotAuthorized as ex:
+        detail = (
+            ex.args[0]
+            if len(ex.args) > 0 and ex.args[0]
+            else "Invalid API key"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail=detail
+        )
+    except SDSNotFoundException:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="SDS not found"
+        )
+    except SDSAPIRateLimitError as ex:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=ex.args[0] if len(ex.args) > 0 and ex.args[0] else "Rate limit exceeded",
+        )
+    except SDSAPIInternalError:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="SDS API request failed",
+        )
+
+
+@router.post(
     "/multipleDetails/",
     description="return list of SDS extracted data",
     response_model=list[schemas.SDSDetailsSchema],

--- a/backend/app/clients/sds_api_client.py
+++ b/backend/app/clients/sds_api_client.py
@@ -204,6 +204,68 @@ class SDSAPIClient:
 
         return response_json
 
+    async def get_dif_language_versions(
+        self,
+        sds_id: dict | None = None,
+        pdf_md5: str | None = None,
+        language_code: str | None = None,
+        fe: bool = False,
+    ):
+        search_data = {}
+        if sds_id:
+            search_data["sds_id"] = sds_id.get("id")
+        if pdf_md5:
+            search_data["pdf_md5"] = pdf_md5
+        if language_code:
+            search_data["language_code"] = language_code
+        if not search_data:
+            raise SDSAPIParamsRequired
+
+        try:
+            response = await self.session.post(
+                url="/sds/getDifLanguageVersions/",
+                json=search_data,
+            )
+        except HTTPError:
+            raise SDSAPIInternalError
+
+        if response.status_code == status.HTTP_401_UNAUTHORIZED:
+            if response.content:
+                raise SDSAPIRequestNotAuthorized(
+                    response.json().get(
+                        "error_message", "You are not authorized"
+                    )
+                )
+            raise SDSAPIRequestNotAuthorized
+        if response.status_code == status.HTTP_429_TOO_MANY_REQUESTS:
+            if response.content:
+                raise SDSAPIRateLimitError(
+                    response.json().get("error_message", "Rate limit exceeded")
+                )
+            raise SDSAPIRateLimitError
+        if response.status_code == status.HTTP_404_NOT_FOUND:
+            raise SDSNotFoundException
+        if response.status_code == status.HTTP_400_BAD_REQUEST:
+            if response.content:
+                raise SDSBadRequestException(
+                    response.json().get("error_message", "Bad request")
+                )
+            raise SDSBadRequestException
+
+        response_jsons: list = response.json()
+        if response.status_code == status.HTTP_200_OK:
+            for response_json in response_jsons:
+                if response_json and isinstance(response_json, dict) and response_json.get("id"):
+                    if fe or self.session.headers.get("SDS-SEARCH-ACCESS-API-KEY") == settings.SDS_API_KEY:
+                        response_json["search_id"] = encrypt_number(
+                            response_json.get("id"),
+                            settings.SECRET_KEY,
+                        )
+                    else:
+                        response_json["search_id"] = response_json.get("id")
+
+        return response_jsons
+
     async def get_multiple_sds_details(
         self,
         sds_id: list[int] = None,

--- a/backend/app/schemas/sds.py
+++ b/backend/app/schemas/sds.py
@@ -35,6 +35,7 @@ class BaseSDSSchema(BaseModel):
     is_current_version: bool | None
     label_generator: str | None
     safety_information_summary: str | None
+    english_sdspdf_id: str | None
     # sds_pdf_chemical_components: list[dict] | None
 
     @validator("id", pre=True)
@@ -59,6 +60,13 @@ class BaseSDSSchema(BaseModel):
     def validate_newest_version_of_sds_id(cls, value, values):
         if isinstance(value, int):
             value =  encrypt_number(value, settings.SECRET_KEY)
+            return value
+        return value
+
+    @validator("english_sdspdf_id", pre=True)
+    def validate_english_sdspdf_id(cls, value):
+        if isinstance(value, int):
+            value = encrypt_number(value, settings.SECRET_KEY)
             return value
         return value
     
@@ -124,6 +132,44 @@ class SearchSDSFilesBodySchema(BaseModel):
     minimum_revision_date: datetime.datetime | None
     is_current_version: bool | None
     is_not_public: bool | None
+
+
+class SDSDifLanguageVersionsBodySchema(BaseModel):
+    sds_id: str | None
+    pdf_md5: str | None
+    language_code: str | None
+
+    @validator("sds_id")
+    def validate_sds_id(cls, value):
+        if value:
+            if is_valid_uuid(value):
+                return {
+                    "id": value,
+                }
+
+            try:
+                return {
+                    "id": decrypt_to_number(value, settings.SECRET_KEY),
+                    "encrypt": f"{value}",
+                }
+            except InvalidToken:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Unknown SDS ID",
+                )
+
+        return value
+
+    @validator("pdf_md5")
+    def validate_pdf_md5(cls, value):
+        if value:
+            if not re.findall(r"^([a-fA-F\d]{32})$", value):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Unknown PDF MD5",
+                )
+
+        return value
 
 
 class SDSDetailsBodySchema(BaseModel):

--- a/backend/app/services/sds_service.py
+++ b/backend/app/services/sds_service.py
@@ -42,6 +42,17 @@ class SDSService:
         )
         return schemas.SDSDetailsSchema(**api_response)
 
+    async def get_dif_language_versions(
+        self, search: schemas.SDSDifLanguageVersionsBodySchema, fe: bool
+    ) -> list[schemas.ListSDSSchema]:
+        api_response = await self.sds_api_client.get_dif_language_versions(
+            sds_id=search.sds_id,
+            pdf_md5=search.pdf_md5,
+            language_code=search.language_code,
+            fe=fe,
+        )
+        return [schemas.ListSDSSchema(**el) for el in api_response if isinstance(el, dict)]
+
     async def get_multiple_sds_details(
         self, search: schemas.MultipleSDSDetailsBodySchema, fe: bool
     ) -> list[schemas.SDSDetailsSchema]:

--- a/frontend/src/components/dif-language-versions-endpoint-details/DifLanguageVersionsEndpointDetails.tsx
+++ b/frontend/src/components/dif-language-versions-endpoint-details/DifLanguageVersionsEndpointDetails.tsx
@@ -1,0 +1,279 @@
+import React from 'react';
+import {
+  FormControl,
+  InputLabel,
+  OutlinedInput,
+  Select,
+  Grid,
+  MenuItem,
+  Button,
+  Table,
+  TableContainer,
+  TableCell,
+  TableHead,
+  TableRow,
+  TableBody,
+  Paper,
+  Typography,
+} from '@mui/material';
+import { useFormik } from 'formik';
+import * as yup from 'yup';
+import axiosInstance from 'api';
+import CustomLoader from 'components/loader/CustomLoader';
+import CheckIcon from '@mui/icons-material/Check';
+import CloseIcon from '@mui/icons-material/Close';
+
+const LANGUAGES = [
+  { code: 'sq', name: 'Albanian' },
+  { code: 'ar', name: 'Arabic' },
+  { code: 'bg', name: 'Bulgarian' },
+  { code: 'zh', name: 'Chinese' },
+  { code: 'hr', name: 'Croatian' },
+  { code: 'cs', name: 'Czech' },
+  { code: 'da', name: 'Danish' },
+  { code: 'nl', name: 'Dutch' },
+  { code: 'en', name: 'English' },
+  { code: 'et', name: 'Estonian' },
+  { code: 'fi', name: 'Finnish' },
+  { code: 'fr', name: 'French' },
+  { code: 'de', name: 'German' },
+  { code: 'el', name: 'Greek' },
+  { code: 'hi', name: 'Hindi' },
+  { code: 'hu', name: 'Hungarian' },
+  { code: 'is', name: 'Icelandic' },
+  { code: 'id', name: 'Indonesian' },
+  { code: 'it', name: 'Italian' },
+  { code: 'ja', name: 'Japanese' },
+  { code: 'ko', name: 'Korean' },
+  { code: 'lv', name: 'Latvian' },
+  { code: 'lt', name: 'Lithuanian' },
+  { code: 'ms', name: 'Malay' },
+  { code: 'no', name: 'Norwegian' },
+  { code: 'pl', name: 'Polish' },
+  { code: 'pt', name: 'Portuguese' },
+  { code: 'ro', name: 'Romanian' },
+  { code: 'ru', name: 'Russian' },
+  { code: 'sr', name: 'Serbian' },
+  { code: 'sk', name: 'Slovak' },
+  { code: 'sl', name: 'Slovenian' },
+  { code: 'es', name: 'Spanish' },
+  { code: 'se', name: 'Swedish' },
+  { code: 'th', name: 'Thai' },
+  { code: 'tr', name: 'Turkish' },
+  { code: 'uk', name: 'Ukrainian' },
+  { code: 'vi', name: 'Vietnamese' },
+];
+
+const DifLanguageVersionsEndpointDetails = () => {
+  const [loading, setLoading] = React.useState<boolean>(false);
+  const [showRawJSON, setShowRawJSON] = React.useState(false);
+  const [sdsResults, setSdsResults] = React.useState<any[]>([]);
+  const [requestDone, setRequestDone] = React.useState<boolean>(false);
+
+  const formSchema = yup.object().shape({
+    sds_id: yup.string(),
+    pdf_md5: yup.string(),
+    language_code: yup.string(),
+  });
+
+  const formik = useFormik({
+    initialValues: {
+      sds_id: '',
+      pdf_md5: '',
+      language_code: '',
+    },
+    onSubmit: (values, { setSubmitting }) => {
+      const apiKey = localStorage.getItem('apiKey');
+      let headers = {};
+      if (apiKey) {
+        headers = { 'X-SDS-SEARCH-ACCESS-API-KEY': apiKey };
+      }
+      setLoading(true);
+      setRequestDone(false);
+      setSdsResults([]);
+      axiosInstance
+        .post(
+          `/sds/get-dif-language-versions/?fe=true`,
+          {
+            sds_id: values.sds_id || undefined,
+            pdf_md5: values.pdf_md5 || undefined,
+            language_code: values.language_code || undefined,
+          },
+          { headers }
+        )
+        .then(function (response) {
+          setSdsResults(response.data);
+          setLoading(false);
+          setRequestDone(true);
+        })
+        .catch(function (error) {
+          setLoading(false);
+          setSubmitting(false);
+          return error.response;
+        });
+      setSubmitting(false);
+    },
+    validationSchema: formSchema,
+    enableReinitialize: true,
+    validateOnMount: true,
+  });
+
+  return (
+    <Grid container spacing={5}>
+      <Grid container item>
+        <Typography>
+          Returns a list of SDS versions in different languages for a given SDS.
+          Provide an SDS ID or PDF MD5 to find matching versions. Optionally
+          specify a language code to filter results to a specific language. Only
+          5 requests per minute is allowed without specified API Key.
+        </Typography>
+      </Grid>
+      <Grid
+        container
+        item
+        direction="row"
+        justifyContent="flex-start"
+        alignItems="flex-start"
+      >
+        <FormControl
+          fullWidth
+          component="form"
+          onSubmit={formik.handleSubmit}
+          autoComplete="off"
+        >
+          <Grid container item direction="row" rowSpacing={2}>
+            <Grid container item spacing={2}>
+              <Grid item xs={4}>
+                <FormControl fullWidth>
+                  <InputLabel htmlFor="sds_id">SDS ID</InputLabel>
+                  <OutlinedInput
+                    fullWidth
+                    id="sds_id"
+                    name="sds_id"
+                    label="SDS ID"
+                    onChange={formik.handleChange}
+                    value={formik.values.sds_id}
+                  />
+                </FormControl>
+              </Grid>
+              <Grid item xs={4}>
+                <FormControl fullWidth>
+                  <InputLabel htmlFor="pdf_md5">PDF MD5</InputLabel>
+                  <OutlinedInput
+                    fullWidth
+                    id="pdf_md5"
+                    name="pdf_md5"
+                    label="PDF MD5"
+                    onChange={formik.handleChange}
+                    value={formik.values.pdf_md5}
+                  />
+                </FormControl>
+              </Grid>
+              <Grid item xs={4}>
+                <FormControl fullWidth>
+                  <InputLabel htmlFor="language_code" shrink>Language</InputLabel>
+                  <Select
+                    fullWidth
+                    id="language_code"
+                    name="language_code"
+                    label="Language"
+                    onChange={formik.handleChange}
+                    value={formik.values.language_code}
+                    displayEmpty
+                    renderValue={(value) => value ? LANGUAGES.find((l) => l.code === value)?.name : 'Any'}
+                  >
+                    <MenuItem value="">
+                      <em>Any</em>
+                    </MenuItem>
+                    {LANGUAGES.map((el) => (
+                      <MenuItem key={el.code} value={el.code}>
+                        {el.name}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              </Grid>
+            </Grid>
+          </Grid>
+          <Grid sx={{ marginTop: '20px' }} container item>
+            <Button
+              variant="contained"
+              disabled={formik.isSubmitting}
+              type="submit"
+            >
+              Search
+            </Button>
+          </Grid>
+        </FormControl>
+      </Grid>
+      <Grid container item>
+        {loading && <CustomLoader />}
+        {!loading && requestDone && sdsResults.length === 0 && (
+          <Typography>No results found</Typography>
+        )}
+        {sdsResults.length > 0 && (
+          <>
+            <Grid container item>
+              <Grid item xs={12}>
+                <Button onClick={() => setShowRawJSON(!showRawJSON)}>
+                  {showRawJSON ? 'Hide' : 'Show'} raw JSON data
+                </Button>
+              </Grid>
+            </Grid>
+            {showRawJSON && (
+              <pre>{JSON.stringify(sdsResults, null, 2)}</pre>
+            )}
+            <TableContainer component={Paper}>
+              <Table sx={{ minWidth: '100%' }}>
+                <TableHead>
+                  <TableRow>
+                    <TableCell align="left">ID</TableCell>
+                    <TableCell align="left">Product Name</TableCell>
+                    <TableCell align="left">Supplier Name</TableCell>
+                    <TableCell align="left">Language</TableCell>
+                    <TableCell align="left">Revision Date</TableCell>
+                    <TableCell align="left">Open PDF</TableCell>
+                    <TableCell align="left">Newest Version</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {sdsResults.map((el: any, index: number) => (
+                    <TableRow
+                      key={index}
+                      sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
+                    >
+                      <TableCell align="left">{el.id}</TableCell>
+                      <TableCell align="left">{el.sds_pdf_product_name}</TableCell>
+                      <TableCell align="left">{el.sds_pdf_manufacture_name}</TableCell>
+                      <TableCell align="left">{el.language}</TableCell>
+                      <TableCell align="left">{el.sds_pdf_revision_date}</TableCell>
+                      <TableCell align="left">
+                        <a
+                          href={el.permanent_link}
+                          style={{ textDecoration: 'none' }}
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          PDF file
+                        </a>
+                      </TableCell>
+                      <TableCell align="left">
+                        {el.is_current_version ? (
+                          <CheckIcon color="success" />
+                        ) : (
+                          <CloseIcon color="error" />
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </>
+        )}
+      </Grid>
+    </Grid>
+  );
+};
+
+export default DifLanguageVersionsEndpointDetails;

--- a/frontend/src/components/documentation/sdsSearchDoc.tsx
+++ b/frontend/src/components/documentation/sdsSearchDoc.tsx
@@ -1029,6 +1029,99 @@ export default function SdsSearchDoc() {
 }'`}</code>
           </pre>
         </div>
+        <div>
+          <h3 style={{ textTransform: 'uppercase', color: '#1976d2' }}>
+            SDS Different Language Versions
+          </h3>
+          <p>
+            Use this endpoint to find SDS versions in different languages for a given SDS.
+            Provide an SDS ID or PDF MD5 to retrieve matching versions. Optionally specify
+            a language code to filter results to a specific language.
+          </p>
+          <ul>
+            <li>
+              <strong>URL:</strong>
+              <p>
+                <code style={styleCodeTag}>
+                  http://api.sdsmanager.com/sds/get-dif-language-versions/
+                </code>
+              </p>
+            </li>
+            <li>
+              <strong>HTTP Method:</strong>
+              <p>
+                <code style={styleCodeTag}>POST</code>
+              </p>
+            </li>
+            <li>
+              <strong>Headers:</strong>
+              <ul>
+                <li>
+                  <code style={styleCodeTag}>Content-Type: application/json</code>
+                  : Indicates that the body of the request is in JSON format.
+                </li>
+                <li>
+                  <code style={styleCodeTag}>Accept: application/json</code>:
+                  Specifies that the client expects a JSON response.
+                </li>
+                <li>
+                  <code style={styleCodeTag}>
+                    X-SDS-SEARCH-ACCESS-API-KEY: [Your API Key]
+                  </code>
+                  : An API key used for authentication, allowing access to the API.
+                </li>
+              </ul>
+            </li>
+            <li>
+              <strong>Data:</strong>
+              <p>
+                The <code style={styleCodeTag}>--data</code> flag is used to send
+                JSON data in the request body. Here's what the JSON data looks like:
+                <pre>
+                  <code style={styleCodeTag}>{`{
+  "sds_id": "<string>",
+  "pdf_md5": "<string>",
+  "language_code": "<string>"
+}`}</code>
+                </pre>
+              </p>
+            </li>
+          </ul>
+          <strong>Explanation of JSON Payload</strong>
+          <ul>
+            <li>
+              <strong>sds_id</strong>: The ID of the SDS (Safety Data Sheet).
+            </li>
+            <li>
+              <strong>pdf_md5</strong>: The MD5 hash of the PDF file associated
+              with the SDS.
+            </li>
+            <li>
+              <strong>language_code</strong>: (Optional) The target language code to filter results (e.g., <code style={styleCodeTag}>"en"</code> for English, <code style={styleCodeTag}>"de"</code> for German). If omitted, all available language versions are returned.
+            </li>
+          </ul>
+          <strong>Example Usage</strong>
+          <pre>
+            <code style={styleCodeTag}>{`curl --location 'https://api.sdsmanager.com/sds/get-dif-language-versions/' \\
+--header 'Content-Type: application/json' \\
+--header 'Accept: application/json' \\
+--header 'X-SDS-SEARCH-ACCESS-API-KEY: [Your API Key]' \\
+--data '{
+  "sds_id": "gAAAAABmWC9apP5PHJ3JeHii_cjrmCJqLdRKd-ql7cgoHqx-1OCjRwdh8sk3tyKiCiUKYZ8k0dNRgKgV_jrJ3xcpnTs7oYvExQ==",
+  "pdf_md5": null,
+  "language_code": "de"
+}'`}</code>
+          </pre>
+          <strong>Response</strong>
+          <p>
+            Returns a list of SDS objects matching the given SDS in the specified language.
+            Each item in the list contains the same fields as the SDS Search response,
+            including <code style={styleCodeTag}>id</code>, <code style={styleCodeTag}>sds_pdf_product_name</code>,{' '}
+            <code style={styleCodeTag}>sds_pdf_manufacture_name</code>, <code style={styleCodeTag}>language</code>,{' '}
+            <code style={styleCodeTag}>sds_pdf_revision_date</code>, <code style={styleCodeTag}>permanent_link</code>, and{' '}
+            <code style={styleCodeTag}>is_current_version</code>.
+          </p>
+        </div>
       </div>
     </>
   );

--- a/frontend/src/components/sds-info-endpoint-details/SDSInfoEndpointDetails.tsx
+++ b/frontend/src/components/sds-info-endpoint-details/SDSInfoEndpointDetails.tsx
@@ -274,6 +274,14 @@ const SDSInfoEndpointDetails = ({
               {sdsDetails.is_current_version ? 'True' : 'False'}
             </Grid>
           </Grid>
+          <Grid container item>
+            <Grid item xs={4}>
+              English SDS PDF
+            </Grid>
+            <Grid item xs={8}>
+              {sdsDetails.english_sdspdf_id ?? 'N/A'}
+            </Grid>
+          </Grid>
 
 
           <Grid container item>

--- a/frontend/src/components/upload-sds-pdf-endpoint-details/UploadSDSPDFEndpointDetails.tsx
+++ b/frontend/src/components/upload-sds-pdf-endpoint-details/UploadSDSPDFEndpointDetails.tsx
@@ -40,6 +40,7 @@ interface SdsDetails {
   replaced_by_id: string | null;
   newest_version_of_sds_id: string | null;
   is_current_version: boolean;
+  english_sdspdf_id: string | null;
   extracted_data?: {
     hazard_codes?: Code[];
     precautionary_codes?: Code[];
@@ -406,6 +407,14 @@ const SDSUploadEndpointDetails: React.FC = () => {
             </Grid>
             <Grid item xs={8}>
               {sdsDetails.is_current_version ? 'True' : 'False'}
+            </Grid>
+          </Grid>
+          <Grid container item>
+            <Grid item xs={4}>
+              English SDS PDF
+            </Grid>
+            <Grid item xs={8}>
+              {sdsDetails.english_sdspdf_id ?? 'N/A'}
             </Grid>
           </Grid>
           {sdsDetails.extracted_data?.hazard_codes && (

--- a/frontend/src/pages/main/Main.tsx
+++ b/frontend/src/pages/main/Main.tsx
@@ -20,6 +20,7 @@ import Documentation from 'components/documentation/documentation';
 import { Visibility, VisibilityOff } from '@material-ui/icons';
 import InfoPanel from '../../components/info-panel/InfoPanel';
 import SdsSafetyInformationSummary from 'components/sds-safety-information-summary';
+import DifLanguageVersionsEndpointDetails from 'components/dif-language-versions-endpoint-details/DifLanguageVersionsEndpointDetails';
 
 interface TabPanelProps {
   children?: React.ReactNode;
@@ -97,7 +98,8 @@ const MainPage = () => {
           <Tab label="SDS Newer revision" {...a11yProps(2)} />
           <Tab label="SDS Upload" {...a11yProps(3)} />
           <Tab label="SDS Safety Information Summary" {...a11yProps(4)} />
-          <Tab label="Documentation" {...a11yProps(5)} />
+          <Tab label="SDS Different Language Versions" {...a11yProps(5)} />
+          <Tab label="Documentation" {...a11yProps(6)} />
         </Tabs>
       </Box>
       <Grid sx={{ marginTop: '20px' }} container justifyContent="flex-end">
@@ -157,10 +159,13 @@ const MainPage = () => {
       <TabPanel value={tabValue} index={3}>
         <SDSUploadEndpointDetails />
       </TabPanel>
-      <TabPanel value={tabValue} index={4}> 
+      <TabPanel value={tabValue} index={4}>
         <SdsSafetyInformationSummary />
       </TabPanel>
       <TabPanel value={tabValue} index={5}>
+        <DifLanguageVersionsEndpointDetails />
+      </TabPanel>
+      <TabPanel value={tabValue} index={6}>
         <Documentation />
       </TabPanel>
     </Box>


### PR DESCRIPTION
## Summary
- Add new `/sds/get-dif-language-versions/` POST endpoint to retrieve SDS versions in different languages by SDS ID, PDF MD5, or language code
- Add `english_sdspdf_id` field to SDS schemas and display it in SDS Info and Upload endpoint details
- Add new "SDS Different Language Versions" tab and component in the frontend UI
- Add API documentation for the new endpoint

## Test plan
- [ ] Verify the `/sds/get-dif-language-versions/` endpoint returns correct results with `sds_id`, `pdf_md5`, and `language_code` params
- [ ] Verify `english_sdspdf_id` field displays correctly in SDS Info and Upload details views
- [ ] Verify the new "SDS Different Language Versions" tab works correctly in the frontend
- [ ] Verify rate limiting (5/min) and error handling (400, 401, 404, 429, 500) on the new endpoint
- [ ] Verify documentation section renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)