### PR TITLE
86c9796dr - Remove Private/Manually Added SDS search checkboxes

### DIFF
--- a/backend/app/clients/sds_api_client.py
+++ b/backend/app/clients/sds_api_client.py
@@ -66,8 +66,6 @@ class SDSAPIClient:
         minimum_revision_date: datetime | None = None,
         region_short_name: str | None = None,
         is_current_version: bool | None = None,
-        is_not_public: bool | None = None,
-        is_manually_added_sds: bool | None = None,
         page: int = 1,
         page_size: int = 20,
         fe: bool = False,
@@ -91,10 +89,6 @@ class SDSAPIClient:
             search_data["is_current_version"] = is_current_version
         elif is_current_version is None:
             search_data["is_current_version"] = "all"
-        if is_not_public and isinstance(is_not_public, bool):
-            search_data["is_not_public"] = is_not_public
-        if is_manually_added_sds and isinstance(is_manually_added_sds, bool):
-            search_data["is_manually_added_sds"] = is_manually_added_sds
 
         try:
             response = await self.session.post(

--- a/backend/app/schemas/sds.py
+++ b/backend/app/schemas/sds.py
@@ -131,8 +131,6 @@ class SearchSDSFilesBodySchema(BaseModel):
     order_by: str | None
     minimum_revision_date: datetime.datetime | None
     is_current_version: bool | None
-    is_not_public: bool | None
-    is_manually_added_sds: bool | None
 
 
 class SDSDifLanguageVersionsBodySchema(BaseModel):

--- a/backend/app/services/sds_service.py
+++ b/backend/app/services/sds_service.py
@@ -24,8 +24,6 @@ class SDSService:
             minimum_revision_date=search.minimum_revision_date,
             region_short_name=search.region_short_name,
             is_current_version=search.is_current_version,
-            is_not_public=search.is_not_public,
-            is_manually_added_sds=search.is_manually_added_sds,
             page=page,
             page_size=page_size,
             fe=fe,

--- a/frontend/src/components/documentation/sdsSearchDoc.tsx
+++ b/frontend/src/components/documentation/sdsSearchDoc.tsx
@@ -201,9 +201,7 @@ export default function SdsSearchDoc() {
     "language_code": "<string>",
     "search_type": "<string>",
     "order_by": "<string>",
-    "minimum_revision_date": "<string>",
-    "is_manually_added_sds": "<boolean>",
-    "is_not_public": "<boolean>"
+    "minimum_revision_date": "<string>"
   }`}</code>
           </pre>
         </p>
@@ -226,10 +224,7 @@ export default function SdsSearchDoc() {
           <li>
             <strong>language_code</strong>: The language code for the search
             results (e.g., <code style={styleCodeTag}>"en"</code> for English).
-            When searching with{' '}
-            <code style={styleCodeTag}>is_manually_added_sds=true</code>,{' '}
-            <code style={styleCodeTag}>language_code</code> should be set to{' '}
-            <code style={styleCodeTag}>"any"</code> so the search includes all
+            Use <code style={styleCodeTag}>"any"</code> to search across all
             languages.
           </li>
           <li>
@@ -263,32 +258,6 @@ export default function SdsSearchDoc() {
             <strong>minimum_revision_date</strong>: Filters results to only
             include those revised after the specified date.
           </li>
-          <li>
-            <strong>is_manually_added_sds</strong>: Use this field to search
-            for SDSs that have been force-inserted (manually added).
-            <ul>
-              <li>
-                Expected value: <code style={styleCodeTag}>true</code> or{' '}
-                <code style={styleCodeTag}>false</code>
-              </li>
-              <li>
-                When using{' '}
-                <code style={styleCodeTag}>is_manually_added_sds=true</code>,{' '}
-                <code style={styleCodeTag}>language_code</code> should be set
-                to <code style={styleCodeTag}>"any"</code>.
-              </li>
-            </ul>
-          </li>
-          <li>
-            <strong>is_not_public</strong>: Use this field to search for
-            private SDSs (not public SDSs).
-            <ul>
-              <li>
-                Expected value: <code style={styleCodeTag}>true</code> or{' '}
-                <code style={styleCodeTag}>false</code>
-              </li>
-            </ul>
-          </li>
         </ul>
 
         <strong>Example Usage</strong>
@@ -311,9 +280,7 @@ export default function SdsSearchDoc() {
   "language_code": "en",
   "search_type": "match",
   "order_by": null,
-  "minimum_revision_date": null,
-  "is_manually_added_sds": false,
-  "is_not_public": false
+  "minimum_revision_date": null
 }'`}</code>
         </pre>
         <p>
@@ -336,9 +303,7 @@ export default function SdsSearchDoc() {
   "language_code": "en",
   "search_type": "match",
   "order_by": "-sds_pdf_revision_date",
-  "minimum_revision_date": null,
-  "is_manually_added_sds": false,
-  "is_not_public": false
+  "minimum_revision_date": null
 }'`}</code>
         </pre>
         <p>
@@ -367,82 +332,7 @@ export default function SdsSearchDoc() {
   "language_code": "en",
   "search_type": "match",
   "order_by": null,
-  "minimum_revision_date": null,
-  "is_manually_added_sds": false,
-  "is_not_public": false
-}'`}</code>
-        </pre>
-        <p>
-          <strong>Search for manually added SDS</strong>
-        </p>
-        <p>
-          To search for SDSs that have been force-inserted (manually added),
-          your <code style={styleCodeTag}>curl</code> command would look like
-          this:
-        </p>
-        <pre>
-          <code
-            style={styleCodeTag}
-          >{`curl --location 'https://api.sdsmanager.com/sds/search/?page_size=10&page=1' \\
---header 'Content-Type: application/json' \\
---header 'Accept: application/json' \\
---header 'X-Sds-Search-Access-Api-Key: [Your API Key]' \\
---data '{
-  "search": "Acetone",
-  "language_code": "any",
-  "search_type": "match",
-  "order_by": null,
-  "minimum_revision_date": null,
-  "is_manually_added_sds": true,
-  "is_not_public": false
-}'`}</code>
-        </pre>
-        <p>
-          <strong>Search for private SDS</strong>
-        </p>
-        <p>
-          To search for private SDSs (not public SDSs), your{' '}
-          <code style={styleCodeTag}>curl</code> command would look like this:
-        </p>
-        <pre>
-          <code
-            style={styleCodeTag}
-          >{`curl --location 'https://api.sdsmanager.com/sds/search/?page_size=10&page=1' \\
---header 'Content-Type: application/json' \\
---header 'Accept: application/json' \\
---header 'X-Sds-Search-Access-Api-Key: [Your API Key]' \\
---data '{
-  "search": "Acetone",
-  "language_code": "en",
-  "search_type": "match",
-  "order_by": null,
-  "minimum_revision_date": null,
-  "is_manually_added_sds": false,
-  "is_not_public": true
-}'`}</code>
-        </pre>
-        <p>
-          <strong>Search for manually added and private SDS</strong>
-        </p>
-        <p>
-          To search for SDSs that are both manually added and private, your{' '}
-          <code style={styleCodeTag}>curl</code> command would look like this:
-        </p>
-        <pre>
-          <code
-            style={styleCodeTag}
-          >{`curl --location 'https://api.sdsmanager.com/sds/search/?page_size=10&page=1' \\
---header 'Content-Type: application/json' \\
---header 'Accept: application/json' \\
---header 'X-Sds-Search-Access-Api-Key: [Your API Key]' \\
---data '{
-  "search": "Acetone",
-  "language_code": "any",
-  "search_type": "match",
-  "order_by": null,
-  "minimum_revision_date": null,
-  "is_manually_added_sds": true,
-  "is_not_public": true
+  "minimum_revision_date": null
 }'`}</code>
         </pre>
       </div>

--- a/frontend/src/components/search-endpoint-details/SearchEndpointDetails.tsx
+++ b/frontend/src/components/search-endpoint-details/SearchEndpointDetails.tsx
@@ -60,8 +60,6 @@ const SearchEndpointDetails = ({
       advanced_search_sku: '',
       region_short_name: 'all',
       is_current_version: true,
-      is_not_public: false,
-      is_manually_added_sds: false,
     },
     onSubmit: (values, { setSubmitting }) => {
       let data = {};
@@ -92,8 +90,6 @@ const SearchEndpointDetails = ({
           order_by: values.order_by,
           minimum_revision_date: values.minimum_revision_date || null,
           is_current_version: values.is_current_version ? "true" : null,
-          is_not_public: values.is_not_public ? "true" : null,
-          is_manually_added_sds: values.is_manually_added_sds ? "true" : null,
         };
       } else {
         data = {
@@ -106,8 +102,6 @@ const SearchEndpointDetails = ({
             : null,
           region_short_name: values.region_short_name,
           is_current_version: values.is_current_version ? "true" : null,
-          is_not_public: values.is_not_public ? "true" : null,
-          is_manually_added_sds: values.is_manually_added_sds ? "true" : null,
         };
       }
       setLoading(true);
@@ -208,11 +202,8 @@ const SearchEndpointDetails = ({
                     label="Language"
                     onChange={formik.handleChange}
                     value={formik.values.language_code}
-                    disabled={formik.values.is_manually_added_sds}
                   >
-                    {formik.values.is_manually_added_sds && (
-                      <MenuItem value="any">Any</MenuItem>
-                    )}
+                    <MenuItem value="any">Any</MenuItem>
                     {[
                       { code: 'sq', name: 'Albanian' },
                       { code: 'ar', name: 'Arabic' },
@@ -415,35 +406,6 @@ const SearchEndpointDetails = ({
                     />
                   }
                   label="Newest Version Only"
-                />
-                <FormControlLabel 
-                  control={
-                    <Checkbox
-                      id="is_not_public"
-                      name="is_not_public"
-                      checked={formik.values.is_not_public ? true : false}
-                      onChange={formik.handleChange}
-                    />
-                  }
-                  label="Private SDS Search"
-                />
-                <FormControlLabel 
-                  control={
-                    <Checkbox
-                      id="is_manually_added_sds"
-                      name="is_manually_added_sds"
-                      checked={formik.values.is_manually_added_sds ? true : false}
-                      onChange={(e) => {
-                        formik.handleChange(e);
-                        if (e.target.checked) {
-                          formik.setFieldValue('language_code', 'any');
-                        } else {
-                          formik.setFieldValue('language_code', 'en');
-                        }
-                      }}
-                    />
-                  }
-                  label="Manually Added SDS Search"
                 />
               </Grid>
             </Grid>


### PR DESCRIPTION
## ClickUp Task
86c9796dr -- https://app.clickup.com/t/86c9796dr

## Description
Remove the "Private SDS Search" (`is_not_public`) and "Manually Added SDS Search" (`is_manually_added_sds`) checkboxes from the search form UI and documentation.

**Frontend changes:**
- Removed both checkboxes and their Formik state from `SearchEndpointDetails.tsx`
- Removed `is_not_public` and `is_manually_added_sds` params from API request payloads
- Language dropdown is no longer conditionally disabled; "Any" option is always visible
- Updated `sdsSearchDoc.tsx`: removed both params from JSON schema, field explanations, curl examples, and the 3 dedicated example sections (manually added, private, combined)

**Backend changes:**
- Removed `is_not_public` and `is_manually_added_sds` from schema, service, and API client

Both params will be hardcoded to `true` server-side so all searches return complete results.

## Migration / CLI steps
None

Generated with [Claude Code](https://claude.com/claude-code)