### PR TITLE
86c9796dr - Fix minimum_revision_date invalid datetime format

### DIFF
--- a/backend/app/clients/sds_api_client.py
+++ b/backend/app/clients/sds_api_client.py
@@ -1,5 +1,4 @@
 import asyncio
-from datetime import datetime
 
 from fastapi import UploadFile
 from fastapi.encoders import jsonable_encoder
@@ -63,7 +62,7 @@ class SDSAPIClient:
         language_code: str | None = None,
         search_type: str | None = None,
         order_by: str | None = "-id",
-        minimum_revision_date: datetime | None = None,
+        minimum_revision_date: str | None = None,
         region_short_name: str | None = None,
         is_current_version: bool | None = None,
         page: int = 1,

--- a/backend/app/schemas/sds.py
+++ b/backend/app/schemas/sds.py
@@ -129,8 +129,23 @@ class SearchSDSFilesBodySchema(BaseModel):
     region_short_name: str | None
     search_type: str | None
     order_by: str | None
-    minimum_revision_date: datetime.datetime | None
+    minimum_revision_date: str | None
     is_current_version: bool | None
+
+    @validator("minimum_revision_date", pre=True)
+    def validate_minimum_revision_date(cls, value):
+        if value is None:
+            return value
+        for fmt in ("%Y-%m-%d", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%dT%H:%M:%S%z"):
+            try:
+                dt = datetime.datetime.strptime(value, fmt)
+                return dt.strftime("%Y-%m-%d")
+            except (ValueError, TypeError):
+                continue
+        raise ValueError(
+            "invalid datetime format, expected YYYY-MM-DD"
+            " or YYYY-MM-DDTHH:MM:SS"
+        )
 
 
 class SDSDifLanguageVersionsBodySchema(BaseModel):

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -49,7 +49,10 @@ axiosInstance.interceptors.response.use(
         if (typeof data.detail === 'string') {
           renderSnackbar([data.detail]);
         } else if (Array.isArray(data.detail)) {
-          renderSnackbar(data.detail);
+          const messages = data.detail.map((item) =>
+            typeof item === 'string' ? item : item.msg
+          );
+          renderSnackbar(messages);
         }
       }
     } catch (e) {


### PR DESCRIPTION
## ClickUp Task
86c9796dr -- https://app.clickup.com/t/86c9796dr

## Description
Fix "invalid datetime format" error when calling /search with `minimum_revision_date` in date-only format (e.g., `"2023-04-26"`).

**Root cause:** The `minimum_revision_date` field in `SearchSDSFilesBodySchema` used `datetime.datetime` type, which Pydantic v1 rejects for date-only strings. The field is now `str` with a custom validator that accepts both `YYYY-MM-DD` and `YYYY-MM-DDTHH:MM:SS` formats and normalizes to `YYYY-MM-DD` before sending to the external API.

Also fixes frontend error message display to properly extract `.msg` from Pydantic validation error detail objects.

**Changes:**
- `backend/app/schemas/sds.py` — Changed field type to `str`, added validator
- `backend/app/clients/sds_api_client.py` — Updated parameter type, removed unused import
- `frontend/src/api/index.js` — Handle object-style error details from Pydantic

## Migration / CLI steps
None

Generated with [Claude Code](https://claude.com/claude-code)