### PR TITLE
86c91jqtg - Fix missing return value in pdf_md5 validator

### DIFF
--- a/backend/app/schemas/sds.py
+++ b/backend/app/schemas/sds.py
@@ -184,6 +184,9 @@ class SDSDifLanguageVersionsBodySchema(BaseModel):
                     detail="Unknown PDF MD5",
                 )
 
+        return value
+
+
 class SDSDetailsBodySchema(BaseModel):
     sds_id: str | None
     pdf_md5: str | None


### PR DESCRIPTION
## ClickUp Task
86c91jqtg — https://app.clickup.com/t/86c91jqtg

## Description
The `validate_pdf_md5` validator in `SDSDifLanguageVersionsBodySchema` was implicitly returning `None` after a valid `pdf_md5` passed the regex check, which caused the user-supplied value to be replaced with `None`.

This PR adds the missing `return value` statement so the validator returns the original value on success, and restores PEP8-compliant 2 blank lines between the schema class definitions.

## Manual steps
None

🤖 Generated with [Claude Code](https://claude.com/claude-code)