### PR TITLE
86c9cjmpp - Support multi-file SDS upload and fix Swedish language code

### DIFF
--- a/backend/app/api/sds.py
+++ b/backend/app/api/sds.py
@@ -20,6 +20,8 @@ from .dependencies import sds_service_dependency
 
 router = APIRouter(prefix="/sds")
 
+MAX_UPLOAD_FILES = 20
+
 
 @router.post(
     "/details/",
@@ -306,13 +308,15 @@ async def search_for_multiple_new_sds_revision_info(
 
 @router.post(
     "/upload/",
-    description="If SDS will be successfully extracted, all information will be returned in response",
-    response_model=schemas.SDSDetailsSchema,
+    description="If SDS will be successfully extracted, all information will be returned in response. Accepts up to 20 PDF files in a single request via repeated 'file' multipart fields.",
+    response_model=(
+        schemas.SDSUploadRequestIdSchema | list[schemas.SDSDetailsSchema]
+    ),
 )
 @limiter.limit("5/minute")
 async def upload_new_sds(
     request: Request,
-    file: UploadFile,
+    file: list[UploadFile],
     sds_service: SDSService = sds_service_dependency,
     fe: bool = Query(False, description="Optional 'fe' parameter"),
     sku: str = Form(default=''),
@@ -321,8 +325,30 @@ async def upload_new_sds(
     private_import: bool = Form(default=False),
     email: str | None = Form(default=None),
 ):
+    if len(file) == 0 or len(file) > MAX_UPLOAD_FILES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Upload between 1 and {MAX_UPLOAD_FILES} PDF files",
+        )
     try:
-        return await sds_service.upload_sds(file=file, fe=fe, sku=sku, upc_ean=upc_ean, product_code=product_code, private_import=private_import, email=email)
+        return await sds_service.upload_sds(
+            files=file,
+            fe=fe,
+            sku=sku,
+            upc_ean=upc_ean,
+            product_code=product_code,
+            private_import=private_import,
+            email=email,
+        )
+    except SDSBadRequestException as ex:
+        detail = (
+            ex.args[0]
+            if len(ex.args) > 0 and ex.args[0]
+            else "Invalid file upload"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=detail
+        )
     except SDSAPIRequestNotAuthorized as ex:
         detail = (
             ex.args[0]

--- a/backend/app/clients/sds_api_client.py
+++ b/backend/app/clients/sds_api_client.py
@@ -468,14 +468,22 @@ class SDSAPIClient:
 
         return response_jsons
 
-    async def upload_sds(self, file: UploadFile, fe: bool = False, sku:str = '', upc_ean:str = '', product_code:str = '', private_import: bool = False, email: str | None = None):
+    async def upload_sds(self, files: list[UploadFile], fe: bool = False, sku:str = '', upc_ean:str = '', product_code:str = '', private_import: bool = False, email: str | None = None):
         try:
-            if file.content_type != "application/pdf":
-                raise SDSBadRequestException("Only PDF files are allowed")
-            file_contents = await file.read()
-            if len(file_contents) > settings.SDS_MAX_FILE_SIZE:
-                raise SDSBadRequestException(
-                    f"File size exceeds the limit of {settings.SDS_MAX_FILE_SIZE / (1024 * 1024)} MB"
+            multipart_files = []
+            for f in files:
+                if f.content_type != "application/pdf":
+                    raise SDSBadRequestException(
+                        "Only PDF files are allowed"
+                    )
+                file_contents = await f.read()
+                if len(file_contents) > settings.SDS_MAX_FILE_SIZE:
+                    raise SDSBadRequestException(
+                        f"File size exceeds the limit of "
+                        f"{settings.SDS_MAX_FILE_SIZE / (1024 * 1024)} MB"
+                    )
+                multipart_files.append(
+                    ("file", (f.filename, file_contents, "application/pdf"))
                 )
             form_data = {
                 "sku": sku,
@@ -483,12 +491,12 @@ class SDSAPIClient:
                 "product_code": product_code,
                 "private_import": private_import,
                 "email": email,
-                "is_fe": fe,              
+                "is_fe": fe,
             }
             response = await self.session.post(
                 url="/sds/upload/",
                 timeout=600,
-                files={"file": (file.filename, file_contents)},
+                files=multipart_files,
                 data=form_data
             )
         except HTTPError:
@@ -531,16 +539,31 @@ class SDSAPIClient:
                 )
             raise SDSAPIInternalError
 
-        response_json: dict = response.json()
+        response_json = response.json()
         if response.status_code == status.HTTP_200_OK:
-            if response_json and response_json.get("id"):
-                if fe or self.session.headers.get("SDS-SEARCH-ACCESS-API-KEY") == settings.SDS_API_KEY:
-                    response_json["search_id"] = encrypt_number(
-                        response_json.get("id"),
-                        settings.SECRET_KEY,
-                    )
-                else:
-                    response_json["search_id"] = response_json.get("id")
+            access_key_match = (
+                fe
+                or self.session.headers.get("SDS-SEARCH-ACCESS-API-KEY")
+                == settings.SDS_API_KEY
+            )
+            items = (
+                response_json
+                if isinstance(response_json, list)
+                else [response_json]
+            )
+            for item in items:
+                if (
+                    item
+                    and isinstance(item, dict)
+                    and item.get("id")
+                ):
+                    if access_key_match:
+                        item["search_id"] = encrypt_number(
+                            item.get("id"),
+                            settings.SECRET_KEY,
+                        )
+                    else:
+                        item["search_id"] = item.get("id")
 
         return response_json
     

--- a/backend/app/schemas/sds.py
+++ b/backend/app/schemas/sds.py
@@ -83,6 +83,13 @@ class SDSDetailsSchema(BaseSDSSchema):
         return value
 
 
+class SDSUploadRequestIdSchema(BaseModel):
+    id: str
+
+    class Config:
+        extra = "forbid"
+
+
 class NewerSDSInfoSchema(BaseModel):
     sds_id: str
     revision_date: datetime.date | None

--- a/backend/app/services/sds_service.py
+++ b/backend/app/services/sds_service.py
@@ -89,16 +89,18 @@ class SDSService:
 
     async def upload_sds(
         self,
-        file: UploadFile,
+        files: list[UploadFile],
         fe: bool,
         sku: str,
         upc_ean: str,
         product_code: str,
         private_import: bool,
         email: str | None = None,
-    ) -> schemas.SDSDetailsSchema:
+    ) -> (
+        schemas.SDSUploadRequestIdSchema | list[schemas.SDSDetailsSchema]
+    ):
         api_response = await self.sds_api_client.upload_sds(
-            file=file,
+            files=files,
             fe=fe,
             sku=sku,
             upc_ean=upc_ean,
@@ -106,7 +108,9 @@ class SDSService:
             private_import=private_import,
             email=email,
         )
-        return schemas.SDSDetailsSchema(**api_response)
+        if fe or len(files) > 1:
+            return schemas.SDSUploadRequestIdSchema(id=api_response["id"])
+        return [schemas.SDSDetailsSchema(**el) for el in api_response]
 
     async def get_extraction_status(
         self, request_id: str, email: str | None, fe: bool

--- a/frontend/src/components/dif-language-versions-endpoint-details/DifLanguageVersionsEndpointDetails.tsx
+++ b/frontend/src/components/dif-language-versions-endpoint-details/DifLanguageVersionsEndpointDetails.tsx
@@ -59,7 +59,7 @@ const LANGUAGES = [
   { code: 'sk', name: 'Slovak' },
   { code: 'sl', name: 'Slovenian' },
   { code: 'es', name: 'Spanish' },
-  { code: 'se', name: 'Swedish' },
+  { code: 'sv', name: 'Swedish' },
   { code: 'th', name: 'Thai' },
   { code: 'tr', name: 'Turkish' },
   { code: 'uk', name: 'Ukrainian' },

--- a/frontend/src/components/search-endpoint-details/SearchEndpointDetails.tsx
+++ b/frontend/src/components/search-endpoint-details/SearchEndpointDetails.tsx
@@ -238,7 +238,7 @@ const SearchEndpointDetails = ({
                       { code: 'sk', name: 'Slovak' },
                       { code: 'sl', name: 'Slovenian' },
                       { code: 'es', name: 'Spanish' },
-                      { code: 'se', name: 'Swedish' },
+                      { code: 'sv', name: 'Swedish' },
                       { code: 'th', name: 'Thai' },
                       { code: 'tr', name: 'Turkish' },
                       { code: 'uk', name: 'Ukrainian' },

--- a/frontend/src/components/upload-sds-pdf-endpoint-details/UploadSDSPDFEndpointDetails.tsx
+++ b/frontend/src/components/upload-sds-pdf-endpoint-details/UploadSDSPDFEndpointDetails.tsx
@@ -172,18 +172,23 @@ const SDSUploadEndpointDetails: React.FC = () => {
         (response) => {
           if (response.status === 200) {
             const data = response.data;
-            setProgress(data.progress || 0);
-            setStep(data.step || '');
-            if (data.progress >= 100 || TERMINAL_STEPS.has(data.step)) {
+            const fileInfoKeys = data.file_info
+              ? Object.keys(data.file_info)
+              : [];
+            const firstFileInfo =
+              fileInfoKeys.length > 0
+                ? data.file_info[fileInfoKeys[0]]
+                : null;
+            const currentProgress =
+              firstFileInfo?.progress ?? data.progress ?? 0;
+            const currentStep = firstFileInfo?.step ?? data.step ?? '';
+            setProgress(currentProgress);
+            setStep(currentStep);
+            if (currentProgress >= 100 || TERMINAL_STEPS.has(currentStep)) {
               clearInterval(getExtractStatusInterval);
               setLoading(false);
-              if (data.file_info) {
-                const fileInfoKeys = Object.keys(data.file_info);
-                if (fileInfoKeys.length > 0) {
-                  const fileInfoKey = fileInfoKeys[0];
-                  const fileInfo = data.file_info[fileInfoKey];
-                  setSdsDetails(fileInfo);
-                }
+              if (firstFileInfo) {
+                setSdsDetails(firstFileInfo);
               }
             }
           }


### PR DESCRIPTION
## ClickUp Task
86c9cjmpp — https://app.clickup.com/t/86c9cjmpp

## Description
### Backend
- `/sds/upload/` now accepts up to 20 PDF files in a single multipart request (repeated `file` fields). Requests outside `[1, 20]` return HTTP 400.
- `SDSService.upload_sds` and `SDSAPIClient.upload_sds` updated to iterate all uploaded files, validate content-type and size per file, and forward them as multiple multipart entries to the upstream API.
- Response model is now a union: `SDSUploadRequestIdSchema | list[SDSDetailsSchema]`. When `fe=true` or more than one file is uploaded, the request id is returned so the frontend can poll extraction status; otherwise a list of full details is returned.
- `SDSBadRequestException` is now caught in the upload route and mapped to HTTP 400.
- Added `SDSUploadRequestIdSchema` in `app/schemas/sds.py`.

### Frontend
- `UploadSDSPDFEndpointDetails`: polling now reads `progress`/`step` from the first entry of `file_info` when present, falling back to the legacy top-level fields. Still sets SDS details from `file_info` on completion.
- Fixed Swedish language code from `se` to `sv` in `SearchEndpointDetails` and `DifLanguageVersionsEndpointDetails` (ISO 639-1 correct code).

## Manual steps
None.