### PR TITLE
86c91jqtg - Temporarily hide SDS Different Language Versions feature

### DIFF
--- a/frontend/src/components/documentation/sdsSearchDoc.tsx
+++ b/frontend/src/components/documentation/sdsSearchDoc.tsx
@@ -1057,6 +1057,7 @@ export default function SdsSearchDoc() {
 }'`}</code>
           </pre>
         </div>
+        {/* Temporarily hidden
         <div>
           <h3 style={{ textTransform: 'uppercase', color: '#1976d2' }}>
             SDS Different Language Versions
@@ -1155,6 +1156,7 @@ export default function SdsSearchDoc() {
             <code style={styleCodeTag}>is_current_version</code>.
           </p>
         </div>
+        */}
       </div>
     </>
   );

--- a/frontend/src/pages/main/Main.tsx
+++ b/frontend/src/pages/main/Main.tsx
@@ -20,7 +20,8 @@ import Documentation from 'components/documentation/documentation';
 import { Visibility, VisibilityOff } from '@material-ui/icons';
 import InfoPanel from '../../components/info-panel/InfoPanel';
 import SdsSafetyInformationSummary from 'components/sds-safety-information-summary';
-import DifLanguageVersionsEndpointDetails from 'components/dif-language-versions-endpoint-details/DifLanguageVersionsEndpointDetails';
+// Temporarily hidden
+// import DifLanguageVersionsEndpointDetails from 'components/dif-language-versions-endpoint-details/DifLanguageVersionsEndpointDetails';
 
 interface TabPanelProps {
   children?: React.ReactNode;
@@ -98,8 +99,10 @@ const MainPage = () => {
           <Tab label="SDS Newer revision" {...a11yProps(2)} />
           <Tab label="SDS Upload" {...a11yProps(3)} />
           <Tab label="SDS Safety Information Summary" {...a11yProps(4)} />
+          {/* Temporarily hidden
           <Tab label="SDS Different Language Versions" {...a11yProps(5)} />
-          <Tab label="Documentation" {...a11yProps(6)} />
+          */}
+          <Tab label="Documentation" {...a11yProps(5)} />
         </Tabs>
       </Box>
       <Grid sx={{ marginTop: '20px' }} container justifyContent="flex-end">
@@ -162,10 +165,12 @@ const MainPage = () => {
       <TabPanel value={tabValue} index={4}>
         <SdsSafetyInformationSummary />
       </TabPanel>
+      {/* Temporarily hidden
       <TabPanel value={tabValue} index={5}>
         <DifLanguageVersionsEndpointDetails />
       </TabPanel>
-      <TabPanel value={tabValue} index={6}>
+      */}
+      <TabPanel value={tabValue} index={5}>
         <Documentation />
       </TabPanel>
     </Box>


### PR DESCRIPTION
## ClickUp Task
86c91jqtg — https://app.clickup.com/t/86c91jqtg

## Description
Temporarily hide the SDS Different Language Versions feature from the demo app:

- Hide the **SDS Different Language Versions** tab in the main page UI (`frontend/src/pages/main/Main.tsx`).
- Hide the corresponding **SDS Different Language Versions** documentation section (including URL, payload, cURL example and response) in `frontend/src/components/documentation/sdsSearchDoc.tsx`.
- Re-index the Documentation tab to slot 5 to fill the gap.
- Comment out the now-unused `DifLanguageVersionsEndpointDetails` import.

All changes use JSX comments (`{/* ... */}`) so the feature can be easily restored later.

## Manual steps
None.