### PR TITLE
86c9cjmpp - Restore single-file /upload/ response shape to object

### DIFF
--- a/backend/app/api/sds.py
+++ b/backend/app/api/sds.py
@@ -310,7 +310,9 @@ async def search_for_multiple_new_sds_revision_info(
     "/upload/",
     description="If SDS will be successfully extracted, all information will be returned in response. Accepts up to 20 PDF files in a single request via repeated 'file' multipart fields.",
     response_model=(
-        schemas.SDSUploadRequestIdSchema | list[schemas.SDSDetailsSchema]
+        schemas.SDSUploadRequestIdSchema
+        | schemas.SDSDetailsSchema
+        | list[schemas.SDSDetailsSchema]
     ),
 )
 @limiter.limit("5/minute")

--- a/backend/app/services/sds_service.py
+++ b/backend/app/services/sds_service.py
@@ -97,7 +97,9 @@ class SDSService:
         private_import: bool,
         email: str | None = None,
     ) -> (
-        schemas.SDSUploadRequestIdSchema | list[schemas.SDSDetailsSchema]
+        schemas.SDSUploadRequestIdSchema
+        | schemas.SDSDetailsSchema
+        | list[schemas.SDSDetailsSchema]
     ):
         api_response = await self.sds_api_client.upload_sds(
             files=files,
@@ -110,6 +112,9 @@ class SDSService:
         )
         if fe or len(files) > 1:
             return schemas.SDSUploadRequestIdSchema(id=api_response["id"])
+        # Preserve pre-#84 contract: single-file sync upload returns one object, not a list.
+        if len(files) == 1:
+            return schemas.SDSDetailsSchema(**api_response[0])
         return [schemas.SDSDetailsSchema(**el) for el in api_response]
 
     async def get_extraction_status(


### PR DESCRIPTION
PR #84 switched /upload/ to accept up to 20 files and always return a list for sync mode (fe=false). That was a breaking change for existing API consumers who upload one file and expect an object (matching the documented synchronous-mode response shape in sdsSearchDoc.tsx).

- Service now returns SDSDetailsSchema (object) when exactly one file is uploaded with fe=false; still returns list[SDSDetailsSchema] for 2-20 files, and SDSUploadRequestIdSchema for fe=true / multi-file flows.
- Widen /upload/ response_model to include the single-object case so OpenAPI reflects all three shapes.