### PR TITLE
86c9cjmpp - Fix single-file /upload/ response unpacking

### DIFF
--- a/backend/app/services/sds_service.py
+++ b/backend/app/services/sds_service.py
@@ -114,7 +114,7 @@ class SDSService:
             return schemas.SDSUploadRequestIdSchema(id=api_response["id"])
         # Preserve pre-#84 contract: single-file sync upload returns one object, not a list.
         if len(files) == 1:
-            return schemas.SDSDetailsSchema(**api_response[0])
+            return schemas.SDSDetailsSchema(**api_response)
         return [schemas.SDSDetailsSchema(**el) for el in api_response]
 
     async def get_extraction_status(

--- a/backend/app/services/sds_service.py
+++ b/backend/app/services/sds_service.py
@@ -96,11 +96,7 @@ class SDSService:
         product_code: str,
         private_import: bool,
         email: str | None = None,
-    ) -> (
-        schemas.SDSUploadRequestIdSchema
-        | schemas.SDSDetailsSchema
-        | list[schemas.SDSDetailsSchema]
-    ):
+    ) -> schemas.SDSUploadRequestIdSchema | schemas.SDSDetailsSchema:
         api_response = await self.sds_api_client.upload_sds(
             files=files,
             fe=fe,
@@ -112,10 +108,7 @@ class SDSService:
         )
         if fe or len(files) > 1:
             return schemas.SDSUploadRequestIdSchema(id=api_response["id"])
-        # Preserve pre-#84 contract: single-file sync upload returns one object, not a list.
-        if len(files) == 1:
-            return schemas.SDSDetailsSchema(**api_response)
-        return [schemas.SDSDetailsSchema(**el) for el in api_response]
+        return schemas.SDSDetailsSchema(**api_response)
 
     async def get_extraction_status(
         self, request_id: str, email: str | None, fe: bool


### PR DESCRIPTION
## ClickUp Task
86c9cjmpp — https://app.clickup.com/t/86c9cjmpp

## Description
Follow-up fix to PR #86. The upstream SDS API returns a single dict (not a list) for the synchronous single-file `/upload/` path, so the previous `api_response[0]` indexing raised `KeyError: 0` on real responses. This passes `api_response` directly into `SDSDetailsSchema`, restoring the pre-#84 single-file response contract.

## Manual steps
None