### PR TITLE
Release prod-17.4.0

### DIFF
--- a/backend/app/services/sds_service.py
+++ b/backend/app/services/sds_service.py
@@ -96,11 +96,7 @@ class SDSService:
         product_code: str,
         private_import: bool,
         email: str | None = None,
-    ) -> (
-        schemas.SDSUploadRequestIdSchema
-        | schemas.SDSDetailsSchema
-        | list[schemas.SDSDetailsSchema]
-    ):
+    ) -> schemas.SDSUploadRequestIdSchema | schemas.SDSDetailsSchema:
         api_response = await self.sds_api_client.upload_sds(
             files=files,
             fe=fe,
@@ -112,10 +108,7 @@ class SDSService:
         )
         if fe or len(files) > 1:
             return schemas.SDSUploadRequestIdSchema(id=api_response["id"])
-        # Preserve pre-#84 contract: single-file sync upload returns one object, not a list.
-        if len(files) == 1:
-            return schemas.SDSDetailsSchema(**api_response[0])
-        return [schemas.SDSDetailsSchema(**el) for el in api_response]
+        return schemas.SDSDetailsSchema(**api_response)
 
     async def get_extraction_status(
         self, request_id: str, email: str | None, fe: bool


### PR DESCRIPTION
* 86c9cjmpp - Fix single-file /upload/ response unpacking

The upstream API returns a single dict (not a list) for synchronous single-file uploads, so indexing with [0] raised KeyError. Pass the response directly into SDSDetailsSchema.



* 86c9cjmpp - Fix single-file /upload/ response unpacking

The upstream API returns a single dict (not a list) for synchronous single-file uploads, so indexing with [0] raised KeyError. Pass the response directly into SDSDetailsSchema, drop the unreachable multi-file branch, and tighten the return type accordingly.



---------