### PR TITLE
chore: allow multiple commits per PR (squashed on merge)

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -17,7 +17,7 @@
 
 ## Commit Rules
 
-- **1 PR = 1 commit.** If there are 2+ commits, squash with `git rebase -i` before opening the PR.
+- **Multiple commits per PR are fine.** Every PR is merged using GitHub's **Squash and merge**, so all commits on your branch collapse into a single commit on the base branch automatically — no need to `git rebase -i` locally. Write meaningful commit messages; the PR title becomes the squashed commit message.
 - Write clear commit messages describing what and why.
 - Prefix the commit message with the ClickUp task ID — e.g., `86c9796dr - Fix minimum_revision_date invalid datetime format`.
 


### PR DESCRIPTION
## Summary
Replaces the old **"1 PR = 1 commit / squash locally with `git rebase -i`"** rule in `.claude/rules/git-workflow.md` with new guidance: **multiple commits per PR are fine**, because every PR is merged using GitHub's **Squash and merge** (commits collapse into one on the base branch automatically).

Wording is identical across all repos so the rule is a single source of truth.

## ClickUp
N/A — workspace-wide squash-merge documentation rollout (no ticket per requester).

## Note
⚠️ This guidance is only safe once each repo enforces **Squash and merge** as the only merge method (merge-commit and rebase-merge disabled). As of now that is **not yet enforced** on any repo — see the separate settings task.