### PR TITLE
Release prod-v17.12.0

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -17,7 +17,7 @@
 
 ## Commit Rules
 
-- **1 PR = 1 commit.** If there are 2+ commits, squash with `git rebase -i` before opening the PR.
+- **Multiple commits per PR are fine.** Every PR is merged using GitHub's **Squash and merge**, so all commits on your branch collapse into a single commit on the base branch automatically — no need to `git rebase -i` locally. Write meaningful commit messages; the PR title becomes the squashed commit message.
 - Write clear commit messages describing what and why.
 - Prefix the commit message with the ClickUp task ID — e.g., `86c9796dr - Fix minimum_revision_date invalid datetime format`.
 


### PR DESCRIPTION
This pull request updates the Git workflow documentation to clarify the commit rules for pull requests. The main change is to allow multiple commits per PR, relying on GitHub's "Squash and merge" feature to combine them automatically, so developers no longer need to squash commits manually before opening a PR.

**Git workflow documentation update:**

* Updated `.claude/rules/git-workflow.md` to state that multiple commits per PR are acceptable, since GitHub's "Squash and merge" will combine them into a single commit, eliminating the need for local squashing.