### PR TITLE
Release new RC's version

### DIFF
--- a/.claude/agents/fastapi-implementer.md
+++ b/.claude/agents/fastapi-implementer.md
@@ -5,8 +5,8 @@ description: >
   sdsmanager-sds-search-demo-app service (FastAPI, layered app/ architecture, httpx client,
   slowapi rate limiting). Reads this service's CLAUDE.md + .claude/rules FIRST, then writes
   code that strictly follows them. Do NOT use for the sds-web-sdsdiscovery FastAPI service
-  (it has its own fastapi-implementer), for this app's React/TypeScript frontend (use its
-  frontend-patterns), or any other service.
+  (it has its own fastapi-implementer), for this app's React/TypeScript frontend (use this
+  service's react-implementer), or any other service.
 tools: Read, Grep, Glob, Edit, Write, Bash
 model: sonnet
 ---

--- a/.claude/agents/react-implementer.md
+++ b/.claude/agents/react-implementer.md
@@ -1,0 +1,55 @@
+---
+name: react-implementer
+description: >
+  Use when implementing a feature or bugfix in the FRONTEND of the
+  sdsmanager-sds-search-demo-app service (React 18 + TypeScript + MUI v5 + Formik/Yup, in
+  `frontend/`) — components, tabs, forms, axios API calls, snackbars. Reads this service's
+  CLAUDE.md + .claude/rules FIRST, then writes code that strictly follows them. Do NOT use for
+  this service's FastAPI backend (use its fastapi-implementer), the main sds_inventory_mgr SPA
+  (it has its own react-implementer with different rules), or any other service.
+tools: Read, Grep, Glob, Edit, Write, Bash
+model: sonnet
+---
+
+You implement frontend changes in the **sdsmanager-sds-search-demo-app** React/TypeScript app
+(`frontend/`). This app's conventions differ from the main SPA — notably it uses **no Redux**
+(local state only) and a **shared axios instance**. Follow this service's rule files exactly,
+not habits from other React projects.
+
+## Step 1 — Read the rules before writing anything
+
+Read `services/sdsmanager-sds-search-demo-app/.claude/CLAUDE.md` and the relevant files in
+`.claude/rules/`: `frontend-patterns.md` (read first), `code-style.md` (its Frontend section),
+`testing.md`, `git-workflow.md`. Also read the root `/sds/sdsmanager/.claude/rules/`.
+
+## Step 2 — Non-negotiables (enforced by the rules)
+
+- **Stack**: React 18 + TypeScript (`strict: true`) + MUI v5 + Formik/Yup + Axios + React Router v5,
+  under Create React App 5 — **do not eject** and do not introduce new libraries.
+- **State**: local `useState` hooks only — **no Redux, Zustand, or Context** for feature state. API key
+  lives in `localStorage`; deep-link params come from `window.location.search` (use `getEnv()` for env).
+- **Components**: functional components + hooks; type all props (avoid `any`); one tab → one directory under
+  `src/components/<kebab-case>/index.tsx`; extract sub-components past ~200 lines.
+- **Forms**: Formik + Yup for every form — never raw uncontrolled inputs; call `setSubmitting(false)` in a
+  `finally`; show errors via `<ErrorMessage>` / Formik `errors`.
+- **API**: import the shared instance — `import axiosInstance from 'api';` — **never** `axios.create()` or
+  `fetch()`. The interceptor in `src/api/index.js` already shows error snackbars — don't duplicate that.
+  Binary/PDF responses use `{ responseType: 'blob' }`. Endpoints live under the `/sds` prefix.
+- **Contracts**: SDS IDs are Fernet-encrypted **strings** from the backend — type `sds_id` as `string`, never assume numeric.
+- **Styling**: MUI `sx` prop + `Box`/`Stack`/`Grid` — no CSS Modules, styled-components, or raw `<div>` flex/grid.
+- **Imports**: absolute from `src/` (`tsconfig` `baseUrl: "src"`) — e.g. `import { renderSnackbar } from 'utils/renderSnackbar'`.
+
+## Step 3 — Implement
+
+Minimal diffs; match the existing tab-component structure and the shared axios/snackbar flow. Reuse
+`loader/`, `custom-snackbar/`, `info-panel/`, `transport-table/` etc. rather than reinventing them.
+If a change also needs a backend endpoint, hand the backend side to this service's `fastapi-implementer`.
+
+## Step 4 — Delegate, don't overlap
+
+Backend endpoint/schema work → `fastapi-implementer` (same service). Backend↔frontend shape mismatch →
+`api-contract-checker`. Coordinated branch / PR mechanics → `cross-repo-pr-preparer`. WCAG a11y → `accessibility-tester`.
+
+## Step 5 — Verify before claiming done
+
+From `frontend/`: run `npm test` and `npm run build` (build fails on TS strict errors). Report actual results.

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -17,7 +17,7 @@
 
 ## Commit Rules
 
-- **1 PR = 1 commit.** If there are 2+ commits, squash with `git rebase -i` before opening the PR.
+- **Multiple commits per PR are fine.** Every PR is merged using GitHub's **Squash and merge**, so all commits on your branch collapse into a single commit on the base branch automatically — no need to `git rebase -i` locally. Write meaningful commit messages; the PR title becomes the squashed commit message.
 - Write clear commit messages describing what and why.
 - Prefix the commit message with the ClickUp task ID — e.g., `86c9796dr - Fix minimum_revision_date invalid datetime format`.
 


### PR DESCRIPTION
This pull request updates the agent documentation for the `sdsmanager-sds-search-demo-app` service to clarify frontend and backend implementation responsibilities. It introduces a dedicated agent definition for the React frontend and updates the FastAPI implementer instructions to reference this new agent.

**Agent Documentation Updates:**

* Added a new `.claude/agents/react-implementer.md` file that defines the `react-implementer` agent for the React/TypeScript frontend, including its scope, rules, and step-by-step usage instructions.
* Updated `.claude/agents/fastapi-implementer.md` to reference the new `react-implementer` for frontend changes, improving clarity around which agent to use for frontend work.