### PR TITLE
86caev9f6 - Expose wish-list-gated hazardous block on /sds/details/

### DIFF
--- a/backend/app/api/sds.py
+++ b/backend/app/api/sds.py
@@ -26,7 +26,7 @@ MAX_UPLOAD_FILES = 20
 @router.post(
     "/details/",
     description="Returns JSON with extracted data of SDS",
-    response_model=schemas.SDSDetailsSchema,
+    response_model=schemas.SDSDetailsWithHazardousSchema,
 )
 @limiter.limit("5/minute")
 async def sds_details(

--- a/backend/app/clients/sds_api_client.py
+++ b/backend/app/clients/sds_api_client.py
@@ -63,6 +63,10 @@ class SDSAPIClient:
         cls._client_registry.clear()
 
     @property
+    def api_key(self) -> str:
+        return self._api_key
+
+    @property
     def session(self) -> AsyncClient:
         return self.get_or_create_client(self._api_key)
 

--- a/backend/app/clients/sds_api_client.py
+++ b/backend/app/clients/sds_api_client.py
@@ -37,10 +37,21 @@ class SDSAPIClient:
                     asyncio.create_task(evicted.aclose())
                 except RuntimeError:
                     pass  # no running event loop, GC will handle it
+            headers = {"SDS-SEARCH-ACCESS-API-KEY": api_key}
+            # Authenticate this gateway to the upstream SDS API so it
+            # includes the wish-list-gated `hazardous` block — but only
+            # for real customer keys: the internal SDS_API_KEY serves the
+            # public sdsmanager.com demo frontend, which must not expose
+            # hazard data to anonymous visitors.
+            if (
+                settings.SDS_GATEWAY_SECRET
+                and api_key != settings.SDS_API_KEY
+            ):
+                headers["SDS-GATEWAY-AUTH"] = settings.SDS_GATEWAY_SECRET
             client = AsyncClient(
                 base_url=settings.SDS_API_URL,
                 timeout=settings.SDS_API_TIMEOUT,
-                headers={"SDS-SEARCH-ACCESS-API-KEY": api_key},
+                headers=headers,
             )
             cls._client_registry[api_key] = client
         return client

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -15,6 +15,10 @@ class Settings(BaseSettings):
     SDS_API_URL: str
     SDS_API_KEY: str | None = None
     SDS_API_TIMEOUT: int = 120
+    # Shared secret proving to the upstream SDS API that a request comes
+    # from this gateway; unlocks the wish-list-gated `hazardous` block on
+    # /sds/details/. Unset = block stays disabled end to end.
+    SDS_GATEWAY_SECRET: str | None = None
     SECRET_KEY: str
     VALUE_LIMIT: int = 100
     REDIS_HOST: str | None = None

--- a/backend/app/schemas/sds.py
+++ b/backend/app/schemas/sds.py
@@ -90,6 +90,30 @@ class SDSUploadRequestIdSchema(BaseModel):
         extra = "forbid"
 
 
+class HazardousComponentSchema(BaseModel):
+    name: str | None
+    cas_no: str | None
+    ec_no: str | None
+    concentration: str | None
+    reach_regulation: str | None
+    regulation_eec: str | None
+    ghs_symbols: list[str] | None
+
+
+class HazardousSchema(BaseModel):
+    is_hazardous: bool | None
+    conforms_to_regulation: str | None
+    components: list[HazardousComponentSchema] | None
+
+
+class SDSDetailsWithHazardousSchema(SDSDetailsSchema):
+    # Wish-list-gated hazardous classification, forwarded from the
+    # upstream SDS API only for /details/ (not /multipleDetails/, which
+    # keeps SDSDetailsSchema). Null when the customer has no wish-list
+    # item for this SDS or the gateway secret is not configured.
+    hazardous: HazardousSchema | None
+
+
 class NewerSDSInfoSchema(BaseModel):
     sds_id: str
     revision_date: datetime.date | None

--- a/backend/app/schemas/sds.py
+++ b/backend/app/schemas/sds.py
@@ -8,6 +8,7 @@ import uuid
 from cryptography.fernet import InvalidToken
 from fastapi import HTTPException
 from pydantic import BaseModel, validator
+from pydantic import ValidationError as PydanticValidationError
 from starlette import status
 
 from app.core.config import settings
@@ -112,6 +113,22 @@ class SDSDetailsWithHazardousSchema(SDSDetailsSchema):
     # keeps SDSDetailsSchema). Null when the customer has no wish-list
     # item for this SDS or the gateway secret is not configured.
     hazardous: HazardousSchema | None
+
+    @validator("hazardous", pre=True)
+    def validate_hazardous(cls, value):
+        # A malformed hazardous block from upstream must degrade to
+        # null, never fail the whole details response — the rest of
+        # the payload (extracted_data etc.) is loose dicts, so this
+        # typed field is the only part that could otherwise 500 an
+        # SDS whose core data is valid.
+        if value is None:
+            return None
+        if not isinstance(value, dict):
+            return None
+        try:
+            return HazardousSchema(**value)
+        except PydanticValidationError:
+            return None
 
 
 class NewerSDSInfoSchema(BaseModel):

--- a/backend/app/services/sds_service.py
+++ b/backend/app/services/sds_service.py
@@ -2,6 +2,7 @@ from fastapi import UploadFile
 
 from app import schemas
 from app.clients.sds_api_client import SDSAPIClient
+from app.core.config import settings
 
 
 class SDSService:
@@ -39,6 +40,14 @@ class SDSService:
             pdf_md5=search.pdf_md5,
             fe=fe,
         )
+        # Defense-in-depth: the public demo frontend (fe / internal
+        # fallback key) must never expose hazard data, even if the
+        # upstream ever attaches the block without checking the
+        # gateway header. The request side already withholds the
+        # header for the fallback key; this makes the invariant
+        # local to the gateway as well.
+        if fe or self.sds_api_client.api_key == settings.SDS_API_KEY:
+            api_response.pop("hazardous", None)
         return schemas.SDSDetailsWithHazardousSchema(**api_response)
 
     async def get_dif_language_versions(

--- a/backend/app/services/sds_service.py
+++ b/backend/app/services/sds_service.py
@@ -32,14 +32,14 @@ class SDSService:
 
     async def get_sds_details(
         self, search: schemas.SDSDetailsBodySchema, fe: bool
-    ) -> schemas.SDSDetailsSchema:
+    ) -> schemas.SDSDetailsWithHazardousSchema:
         api_response = await self.sds_api_client.get_sds_details(
             sds_id=search.sds_id,
             language_code=search.language_code,
             pdf_md5=search.pdf_md5,
             fe=fe,
         )
-        return schemas.SDSDetailsSchema(**api_response)
+        return schemas.SDSDetailsWithHazardousSchema(**api_response)
 
     async def get_dif_language_versions(
         self, search: schemas.SDSDifLanguageVersionsBodySchema, fe: bool

--- a/frontend/src/components/documentation/sdsSearchDoc.tsx
+++ b/frontend/src/components/documentation/sdsSearchDoc.tsx
@@ -425,6 +425,54 @@ export default function SdsSearchDoc() {
   "language_code": null
 }'`}</code>
         </pre>
+        <strong>Response: hazardous classification</strong>
+        <p>
+          In addition to the extracted SDS data, the response includes a{' '}
+          <code style={styleCodeTag}>hazardous</code> field with the hazard
+          classification of the product. It is populated only when the
+          requested SDS is in your SDS library (wish list); for any other
+          SDS the field is <code style={styleCodeTag}>null</code>.
+          <pre>
+            <code style={styleCodeTag}>{`{
+  ...,
+  "hazardous": {
+    "is_hazardous": true,
+    "conforms_to_regulation": "EU GHS / CLP",
+    "components": [
+      {
+        "name": "Methanol",
+        "cas_no": "67-56-1",
+        "ec_no": "200-659-6",
+        "concentration": "10-30%",
+        "reach_regulation": "SVHC",
+        "regulation_eec": "",
+        "ghs_symbols": ["GHS02", "GHS06"]
+      }
+    ]
+  }
+}`}</code>
+          </pre>
+        </p>
+        <strong>Explanation of the hazardous field</strong>
+        <ul>
+          <li>
+            <strong>is_hazardous</strong>: Whether the product contains
+            hazardous chemicals.
+          </li>
+          <li>
+            <strong>conforms_to_regulation</strong>: The regulation the SDS
+            conforms to (e.g., "EU GHS / CLP"), or{' '}
+            <code style={styleCodeTag}>null</code> when not determined.
+          </li>
+          <li>
+            <strong>components</strong>: The chemical components of the
+            product, including any edits made in your SDS library. Each
+            component lists its name, CAS and EC numbers, concentration,
+            REACH and EEC regulation classification, and GHS pictogram
+            codes (<code style={styleCodeTag}>ghs_symbols</code>). The list
+            is empty when no component data has been extracted.
+          </li>
+        </ul>
       </div>
       <div>
         <h3 style={{ textTransform: 'uppercase', color: '#1976d2' }}>


### PR DESCRIPTION
## ClickUp Task
86caev9f6 — https://app.clickup.com/t/86caev9f6

## Description
Completes the pipeline so **api.sdsmanager.com is the only surface where customers receive the `hazardous` classification block**, per the task owner's instruction. The upstream SDS API (companion sdsadmin PR: https://github.com/SDS-Manager/sdsadmin/pull/2207) attaches the block to `/sds/details/` responses only for requests authenticated as coming from this gateway.

Changes:
- **`SDS_GATEWAY_SECRET` config** — sent upstream as the `SDS-GATEWAY-AUTH` header, and **only for real customer API keys**: the internal `SDS_API_KEY` fallback serves the public sdsmanager.com demo frontend, which must not expose hazard data to anonymous visitors. Unset secret = feature disabled end to end.
- **Typed schemas** `HazardousSchema` / `HazardousComponentSchema`, and `SDSDetailsWithHazardousSchema` used **only by `/sds/details/`** — the `/sds/multipleDetails/` contract is byte-for-byte unchanged (it keeps `SDSDetailsSchema`). Swagger now documents the new field automatically.
- `hazardous` serializes as `null` when the customer has no wish-list item for the SDS (upstream omits the key) or the secret is unconfigured.

Verified locally end-to-end against a local upstream: block present through the gateway with a real customer key; `hazardous: null` on the demo-frontend fallback path even when the fallback key itself is fully privileged; `/multipleDetails/` unchanged; upstream's `english_sdspdf_id` encryption validator intact through the schema subclass.

## Manual steps
- Set `SDS_GATEWAY_SECRET` in each gateway environment — **same value** as the upstream's `PUBLIC_API_HAZARDOUS_GATEWAY_SECRET`.
- Deploy **after** the companion sdsadmin PR; until both are live the field simply stays absent (today's behavior).
- Note: `SDS_API_URL` must include the `/api/public` prefix (existing deployments already do).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Code review hardening (2ea6b11)
- Malformed `hazardous` from upstream degrades to `null` (pre-validator) instead of 500ing the response.
- `hazardous` is additionally stripped server-side for the demo frontend path (`fe` / internal fallback key) — the demo invariant no longer depends on upstream behavior.
- Note: the shared secret is only honored upstream after API-key validation (`PDFSearchAPIPermission` runs before the view), so an invalid key gets 401 before any hazardous logic.

## Developer docs (3f57e02)
Added the `hazardous` field to the SDS Details section of the developer docs page (`sdsSearchDoc.tsx`): wish-list condition, example response, and field explanations. Together with the Swagger schema this completes the task's "documented in API developer docs" acceptance criterion.